### PR TITLE
Fix instructions for running jupyter with tcl kernel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Install via:
     
     python3 -m tcl_kernel.install
     
-To use try one of these::
+To use try one of these:
     - jupyter notebook
         - Then select the Tcl option in the 'New' section
     - jupyter qtconsole --kernel tcl

--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@ Install via:
     python3 -m tcl_kernel.install
     
 To use try one of these::
-    jupyter notebook
-    # Then select the Tcl option in the 'New' section
-    jupyter qtconsole --kernel tcl
-    jupyter console --kernel tcl
+    - jupyter notebook
+        - Then select the Tcl option in the 'New' section
+    - jupyter qtconsole --kernel tcl
+    - jupyter console --kernel tcl
 
 
 For details of how this works, see the Jupyter docs on `wrapper kernels


### PR DESCRIPTION
All the options were displaying on one line.